### PR TITLE
[CONSOLE-002] Fixed Bug with Interactive Mode Quitting

### DIFF
--- a/registermaschine-console/src/main/java/dk/tij/registermaschine/console/ConsoleApplication.java
+++ b/registermaschine-console/src/main/java/dk/tij/registermaschine/console/ConsoleApplication.java
@@ -70,11 +70,6 @@ public class ConsoleApplication {
                 exec.setProgram(singleStep);
                 cpu.resetProgrammeCounter();
                 exec.run();
-
-                if (cpu.isHalted()) {
-                    System.out.println("CPU is halted. Terminating...");
-                    break;
-                }
             } catch (SyntaxErrorException e) {
                 System.err.printf("%s: %s%n", e.getClass().getSimpleName(), e.getMessage());
             }

--- a/registermaschine-console/src/main/java/dk/tij/registermaschine/console/MachineListener.java
+++ b/registermaschine-console/src/main/java/dk/tij/registermaschine/console/MachineListener.java
@@ -18,13 +18,8 @@ public class MachineListener implements IExecutionContextListener {
         this.context = ctx;
     }
 
-    @Override
-    public void onExecutionStarted() {}
-
-    @Override
-    public void onExecutionStopped() {
-        System.out.println("Stopped Execution");
-    }
+    @Override public void onExecutionStarted() {}
+    @Override public void onExecutionStopped() {}
 
     @Override
     public void onRegisterChanged(int index, int newValue) {
@@ -41,8 +36,7 @@ public class MachineListener implements IExecutionContextListener {
         System.out.println("Exit Code: " + newValue);
     }
 
-    @Override
-    public void onProgrammeCounterChanged(int newPc) {}
+    @Override public void onProgrammeCounterChanged(int newPc) {}
 
     @Override
     public void onMaxJumpsReached() {


### PR DESCRIPTION
Interactive mode was quitting after the very first instruction. This problem was resolved by using the CORE#Executor's features of having the monopoly over halting programs.

(Resolves #36)