### PR TITLE
(#47) Fixed Bug With Negative Immediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 ## Changes
 ### CORE
 - Added support for underscores in labels in default implementations for `ConcreteLexer` and `ConcreteParser`
+- Added support for negative immediate values in `ConcreteLexer` Added support for negative immediate values in `ConcreteLexer` 
 ## Breaking Changes
 ### API
 #### Minor
 - Introducing another `TokenType` called `ADDRESS` to differentiate between actual labels and real hard addresses.\
     `ILexer` and `IParser` implementations need to accommodate for this new type.
+

--- a/registermaschine-core/src/main/java/dk/tij/registermaschine/core/compilation/ConcreteLexer.java
+++ b/registermaschine-core/src/main/java/dk/tij/registermaschine/core/compilation/ConcreteLexer.java
@@ -71,6 +71,10 @@ public final class ConcreteLexer implements ILexer {
             return;
         }
 
+        if (peek() == '-') {
+            sb.append(advance());
+        }
+
         if (peek() == '0') {
             char zero = advance();
             if (isNotAtEnd() && (peek() == 'x' || peek() == 'X')) {


### PR DESCRIPTION
Fixed bug where no negative numbers were allowed after the immediate prefix.